### PR TITLE
module for setting element attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,15 @@ h('a', {props: {href: '/foo'}, 'Go to Foo');
 
 ### The attributes module
 
-Same as props but set attributes instead of properties on DOM elements (i.e. `setAttribute`).
+Same as props but set attributes instead of properties on DOM elements
 
 ```javascript
 h('a', {attrs: {href: '/foo'}, 'Go to Foo');
 ```
+
+Attributes are added and updated using `setAttribute`. In case of an attribute that has been previously added/set is no longer present in the `attrs` object, it is removed from the DOM elemnt's attribute list using `removeAttribute`. 
+
+In the case of boolean attributes (.e.g. `disabled`, `hidden`, `selected` ...). The meaning doesn't depend on the attribute value (`true` of `false`) but depends instead on the presence/absence of the attribute itself in the DOM element. Those attributes are handled differently by the module : if a boolean attribute is set to a [falsy value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) (`0`, `-0`, `null`, `false`, `NaN`, `undefined`, or the empty string (`""`)) then the attribute will be removed from the attribute list of the DOM element.
 
 ### The style module
 

--- a/README.md
+++ b/README.md
@@ -201,10 +201,10 @@ h('a', {props: {href: '/foo'}, 'Go to Foo');
 Same as props but set attributes instead of properties on DOM elements
 
 ```javascript
-h('a', {attrs: {href: '/foo'}, 'Go to Foo');
+h('a', { attrs: {href: '/foo'} }, 'Go to Foo');
 ```
 
-Attributes are added and updated using `setAttribute`. In case of an attribute that has been previously added/set is no longer present in the `attrs` object, it is removed from the DOM elemnt's attribute list using `removeAttribute`. 
+Attributes are added and updated using `setAttribute`. In case of an attribute that has been previously added/set is no longer present in the `attrs` object, it is removed from the DOM element's attribute list using `removeAttribute`. 
 
 In the case of boolean attributes (.e.g. `disabled`, `hidden`, `selected` ...). The meaning doesn't depend on the attribute value (`true` of `false`) but depends instead on the presence/absence of the attribute itself in the DOM element. Those attributes are handled differently by the module : if a boolean attribute is set to a [falsy value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) (`0`, `-0`, `null`, `false`, `NaN`, `undefined`, or the empty string (`""`)) then the attribute will be removed from the attribute list of the DOM element.
 

--- a/README.md
+++ b/README.md
@@ -204,9 +204,17 @@ Same as props but set attributes instead of properties on DOM elements
 h('a', { attrs: {href: '/foo'} }, 'Go to Foo');
 ```
 
-Attributes are added and updated using `setAttribute`. In case of an attribute that has been previously added/set is no longer present in the `attrs` object, it is removed from the DOM element's attribute list using `removeAttribute`. 
+Attributes are added and updated using `setAttribute`. In case of an attribute 
+that has been previously added/set is no longer present in the `attrs` object, 
+it is removed from the DOM element's attribute list using `removeAttribute`. 
 
-In the case of boolean attributes (.e.g. `disabled`, `hidden`, `selected` ...). The meaning doesn't depend on the attribute value (`true` of `false`) but depends instead on the presence/absence of the attribute itself in the DOM element. Those attributes are handled differently by the module : if a boolean attribute is set to a [falsy value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) (`0`, `-0`, `null`, `false`, `NaN`, `undefined`, or the empty string (`""`)) then the attribute will be removed from the attribute list of the DOM element.
+In the case of boolean attributes (.e.g. `disabled`, `hidden`, `selected` ...). 
+The meaning doesn't depend on the attribute value (`true` or `false`) but depends
+instead on the presence/absence of the attribute itself in the DOM element. Those 
+attributes are handled differently by the module : if a boolean attribute is set 
+to a [falsy value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) (`0`, `-0`, `null`, `false`,`NaN`, `undefined`, or the empty 
+string (`""`)) then the attribute will be removed from the attribute list of the
+DOM element.
 
 ### The style module
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ Allows you to set properties on DOM elements.
 h('a', {props: {href: '/foo'}, 'Go to Foo');
 ```
 
+### The attributes module
+
+Same as props but set attributes instead of properties on DOM elements (i.e. `setAttribute`).
+
+```javascript
+h('a', {attrs: {href: '/foo'}, 'Go to Foo');
+```
+
 ### The style module
 
 The style module is for making your HTML look slick and animate smoothly. At

--- a/modules/attributes.js
+++ b/modules/attributes.js
@@ -12,7 +12,7 @@ function updateAttrs(oldVnode, vnode) {
     }
   }
   //remove removed attributes
-  // use `in` operator since the previous `for` iterations uses it (.i.e. )
+  // use `in` operator since the previous `for` iteration uses it (.i.e. add even attributes with undefined value)
   // the other option is to remove all attributes with value == undefined
   for (key in oldAttrs) {
     if (!(key in attrs)) {

--- a/modules/attributes.js
+++ b/modules/attributes.js
@@ -1,0 +1,24 @@
+function updateAttrs(oldVnode, vnode) {
+  var key, cur, old, elm = vnode.elm,
+      oldAttrs = oldVnode.data.attrs || {}, attrs = vnode.data.attrs || {};
+  
+  // update modified attributes, add new attributes
+  for (key in attrs) {
+    cur = attrs[key];
+    old = oldAttrs[key];
+    if (old !== cur) {
+      // TODO: add support to namespaced attributes (setAttributeNS)
+      elm.setAttribute(key, cur);
+    }
+  }
+  //remove removed attributes
+  // use `in` operator since the previous `for` iterations uses it (.i.e. )
+  // the other option is to remove all attributes with value == undefined
+  for (key in oldAttrs) {
+    if (!(key in attrs)) {
+      elm.removeAttribute(key);
+    }
+  }
+}
+
+module.exports = {create: updateAttrs, update: updateAttrs};

--- a/modules/attributes.js
+++ b/modules/attributes.js
@@ -1,7 +1,15 @@
-function isBooleanAttribute(attrName) {
-  return (/^(?:allowfullscreen|async|autofocus|autoplay|checked|compact|controls|declare|default|defaultchecked|defaultmuted|defaultselected|defer|disabled|draggable|enabled|formnovalidate|hidden|indeterminate|inert|ismap|itemscope|loop|multiple|muted|nohref|noresize|noshade|novalidate|nowrap|open|pauseonexit|readonly|required|reversed|scoped|seamless|selected|sortable|spellcheck|translate|truespeed|typemustmatch|visible)$/).test(attrName);
+var booleanAttrs = ["allowfullscreen", "async", "autofocus", "autoplay", "checked", "compact", "controls", "declare", 
+                "default", "defaultchecked", "defaultmuted", "defaultselected", "defer", "disabled", "draggable", 
+                "enabled", "formnovalidate", "hidden", "indeterminate", "inert", "ismap", "itemscope", "loop", "multiple", 
+                "muted", "nohref", "noresize", "noshade", "novalidate", "nowrap", "open", "pauseonexit", "readonly", 
+                "required", "reversed", "scoped", "seamless", "selected", "sortable", "spellcheck", "translate", 
+                "truespeed", "typemustmatch", "visible"];
+    
+var booleanAttrsDict = {};
+for(var i=0, len = booleanAttrs.length; i < len; i++) {
+  booleanAttrsDict[booleanAttrs[i]] = true;
 }
-
+    
 function updateAttrs(oldVnode, vnode) {
   var key, cur, old, elm = vnode.elm,
       oldAttrs = oldVnode.data.attrs || {}, attrs = vnode.data.attrs || {};
@@ -12,7 +20,7 @@ function updateAttrs(oldVnode, vnode) {
     old = oldAttrs[key];
     if (old !== cur) {
       // TODO: add support to namespaced attributes (setAttributeNS)
-      if(!cur && isBooleanAttribute(key))
+      if(!cur && booleanAttrsDict[key])
         elm.removeAttribute(key);
       else
         elm.setAttribute(key, cur);

--- a/modules/attributes.js
+++ b/modules/attributes.js
@@ -1,5 +1,5 @@
 function isBooleanAttribute(attrName) {
-    return (/^(?:allowfullscreen|async|autofocus|autoplay|checked|compact|controls|declare|default|defaultchecked|defaultmuted|defaultselected|defer|disabled|draggable|enabled|formnovalidate|hidden|indeterminate|inert|ismap|itemscope|loop|multiple|muted|nohref|noresize|noshade|novalidate|nowrap|open|pauseonexit|readonly|required|reversed|scoped|seamless|selected|sortable|spellcheck|translate|truespeed|typemustmatch|visible)$/).test(attrName);
+  return (/^(?:allowfullscreen|async|autofocus|autoplay|checked|compact|controls|declare|default|defaultchecked|defaultmuted|defaultselected|defer|disabled|draggable|enabled|formnovalidate|hidden|indeterminate|inert|ismap|itemscope|loop|multiple|muted|nohref|noresize|noshade|novalidate|nowrap|open|pauseonexit|readonly|required|reversed|scoped|seamless|selected|sortable|spellcheck|translate|truespeed|typemustmatch|visible)$/).test(attrName);
 }
 
 function updateAttrs(oldVnode, vnode) {

--- a/modules/attributes.js
+++ b/modules/attributes.js
@@ -1,3 +1,7 @@
+function isBooleanAttribute(attrName) {
+    return (/^(?:allowfullscreen|async|autofocus|autoplay|checked|compact|controls|declare|default|defaultchecked|defaultmuted|defaultselected|defer|disabled|draggable|enabled|formnovalidate|hidden|indeterminate|inert|ismap|itemscope|loop|multiple|muted|nohref|noresize|noshade|novalidate|nowrap|open|pauseonexit|readonly|required|reversed|scoped|seamless|selected|sortable|spellcheck|translate|truespeed|typemustmatch|visible)$/).test(attrName);
+}
+
 function updateAttrs(oldVnode, vnode) {
   var key, cur, old, elm = vnode.elm,
       oldAttrs = oldVnode.data.attrs || {}, attrs = vnode.data.attrs || {};
@@ -8,7 +12,10 @@ function updateAttrs(oldVnode, vnode) {
     old = oldAttrs[key];
     if (old !== cur) {
       // TODO: add support to namespaced attributes (setAttributeNS)
-      elm.setAttribute(key, cur);
+      if(!cur && isBooleanAttribute(key))
+        elm.removeAttribute(key);
+      else
+        elm.setAttribute(key, cur);
     }
   }
   //remove removed attributes


### PR DESCRIPTION
Attributes are added and updated using `setAttribute`. In case of an attribute that has been previously added/set is no longer present in the `attrs` object, it is removed from the DOM element's attribute list using `removeAttribute`. 

In the case of HTML boolean attributes (.e.g. `disabled`, `hidden`, `selected` ...) attributes are removed if the attribute value is falsy in the JavaScript sens.