### PR TITLE
Keep original handler object

### DIFF
--- a/modules/eventlisteners.js
+++ b/modules/eventlisteners.js
@@ -11,6 +11,13 @@ function fnInvoker(o) {
   return function(ev) { o.fn(ev); };
 }
 
+function assoc(k, v, obj) {
+  var keys = Object.keys(obj), i = keys.length, copy = {};
+  while (i--) copy[keys[i]] = obj[keys[i]];
+  copy[k] = v;
+  return copy;
+}
+
 function updateEventListeners(oldVnode, vnode) {
   var name, cur, old, elm = vnode.elm,
       oldOn = oldVnode.data.on || {}, on = vnode.data.on;
@@ -23,17 +30,17 @@ function updateEventListeners(oldVnode, vnode) {
         elm.addEventListener(name, arrInvoker(cur));
       } else {
         cur = {fn: cur};
-        on[name] = cur;
+        vnode.data.on = assoc(name, cur, on);
         elm.addEventListener(name, fnInvoker(cur));
       }
     } else if (is.array(old)) {
       // Deliberately modify old array since it's captured in closure created with `arrInvoker`
       old.length = cur.length;
       for (var i = 0; i < old.length; ++i) old[i] = cur[i];
-      on[name]  = old;
+      vnode.data.on = assoc(name, old, on);
     } else {
       old.fn = cur;
-      on[name] = old;
+      vnode.data.on = assoc(name, old, on);
     }
   }
 }


### PR DESCRIPTION
The eventlistener helper is directly modifying the handler object (the `on` part of `data` passed to `h`). `data` will be silently modified and if the user want to reuse it, for example, in a loop, it has to be cloned on every call to `h`.
I don't know if my fix is correct, but I think this is a serious problem.