### PR TITLE
Fixed hero example to account for #container being overwritten.

### DIFF
--- a/examples/hero/build.js
+++ b/examples/hero/build.js
@@ -60,7 +60,7 @@ var overviewView = function overviewView(movies) {
 };
 
 var view = function view(data) {
-  return h('div', [data.selected ? detailView(data.selected) : overviewView(data.movies)]);
+  return h('div.page-container', [data.selected ? detailView(data.selected) : overviewView(data.movies)]);
 };
 
 window.addEventListener('DOMContentLoaded', function () {

--- a/examples/hero/index.html
+++ b/examples/hero/index.html
@@ -17,7 +17,7 @@
         background: #fff;
         font-family: sans-serif;
       }
-      #container {
+      .page-container {
         width: 100%;
         position: relative;
         background: #fff;
@@ -31,7 +31,7 @@
           justify-content: center;
           background: #aaaaaa;
         }
-        #container {
+        .page-container {
           box-shadow: 0 0 1em rgba(0, 0, 0, .5);
           width: 28em;
           min-height: 38em;

--- a/examples/hero/script.js
+++ b/examples/hero/script.js
@@ -109,7 +109,7 @@ const overviewView = (movies) =>
   ]);
 
 const view = (data) =>
-  h('div', [
+  h('div.page-container', [
     data.selected ? detailView(data.selected) : overviewView(data.movies),
   ]);
 


### PR DESCRIPTION
The hero animation example was not showing correctly (width would be 100% of device width, even on desktop).

The CSS was targeting the app container, which gets replaced as soon as the app starts.  I changed the CSS to target the wrapper div which is part of the vdom, and it looks right again.