### PR TITLE
Fixed 'Uncaught ReferenceError'

### DIFF
--- a/modules/style.js
+++ b/modules/style.js
@@ -1,4 +1,4 @@
-var raf = requestAnimationFrame || setTimeout;
+var raf = (window && window.requestAnimationFrame) || setTimeout;
 var nextFrame = function(fn) { raf(function() { raf(fn); }); };
 
 function setNextFrame(obj, prop, val) {


### PR DESCRIPTION
When using snabbdom with webpack, the webpack output file is in strict mode, and that would cause error:

> Uncaught ReferenceError: requestAnimationFrame is not defined at ...

This pull request fixed it.