### PR TITLE
Added failing style tests

### DIFF
--- a/test/style.js
+++ b/test/style.js
@@ -32,6 +32,39 @@ describe('style', function() {
     assert.equal(elm.style.fontSize, '10px');
     assert.equal(elm.style.display, 'block');
   });
+  it('explicialy removes styles', function() {
+    var vnode1 = h('i', {style: {fontSize: '14px'}});
+    var vnode2 = h('i', {style: {fontSize: ''}});
+    var vnode3 = h('i', {style: {fontSize: '10px'}});
+    patch(vnode0, vnode1);
+    assert.equal(elm.style.fontSize, '14px');
+    patch(vnode1, vnode2);
+    assert.equal(elm.style.fontSize, '');
+    patch(vnode2, vnode3);
+    assert.equal(elm.style.fontSize, '10px');
+  });
+  it('implicially removes styles from element with key', function() {
+    var vnode1 = h('i', {key: '1', style: {fontSize: '14px'}});
+    var vnode2 = h('i', {key: '2'});
+    var vnode3 = h('i', {key: '1', style: {fontSize: '10px'}});
+    patch(vnode0, vnode1);
+    assert.equal(elm.style.fontSize, '14px');
+    patch(vnode1, vnode2);
+    assert.equal(elm.style.fontSize, '');
+    patch(vnode2, vnode3);
+    assert.equal(elm.style.fontSize, '10px');
+  });
+  it('implicially removes styles from child when parent element has key', function() {
+    var vnode1 = h('div', {key: '1'}, [h('i', {style: {fontSize: '14px'}})]);
+    var vnode2 = h('div', {key: '2'}, [h('i')]);
+    var vnode3 = h('div', {key: '1'}, [h('i', {style: {fontSize: '10px'}})]);
+    patch(vnode0, vnode1);
+    assert.equal(elm.firstChild.style.fontSize, '14px');
+    patch(vnode1, vnode2);
+    assert.equal(elm.firstChild.style.fontSize, '');
+    patch(vnode2, vnode3);
+    assert.equal(elm.firstChild.style.fontSize, '10px');
+  });
   it('updates delayed styles in next frame', function() {
     var patch = snabbdom.init([
       require('../modules/style'),

--- a/test/style.js
+++ b/test/style.js
@@ -44,9 +44,9 @@ describe('style', function() {
     assert.equal(elm.style.fontSize, '10px');
   });
   it('implicially removes styles from element with key', function() {
-    var vnode1 = h('i', {key: '1', style: {fontSize: '14px'}});
-    var vnode2 = h('i', {key: '2'});
-    var vnode3 = h('i', {key: '1', style: {fontSize: '10px'}});
+    var vnode1 = h('div', [h('i', {key: '1', style: {fontSize: '14px'}})]);
+    var vnode2 = h('div', [h('i', {key: '2'})]);
+    var vnode3 = h('div', [h('i', {key: '1', style: {fontSize: '10px'}})]);
     patch(vnode0, vnode1);
     assert.equal(elm.style.fontSize, '14px');
     patch(vnode1, vnode2);
@@ -55,9 +55,9 @@ describe('style', function() {
     assert.equal(elm.style.fontSize, '10px');
   });
   it('implicially removes styles from child when parent element has key', function() {
-    var vnode1 = h('div', {key: '1'}, [h('i', {style: {fontSize: '14px'}})]);
-    var vnode2 = h('div', {key: '2'}, [h('i')]);
-    var vnode3 = h('div', {key: '1'}, [h('i', {style: {fontSize: '10px'}})]);
+    var vnode1 = h('div', [h('span', {key: '1'}, [h('i', {style: {fontSize: '14px'}})])]);
+    var vnode2 = h('div', [h('span', {key: '2'}, [h('i')])]);
+    var vnode3 = h('div', [h('span', {key: '1'}, [h('i', {style: {fontSize: '10px'}})])]);
     patch(vnode0, vnode1);
     assert.equal(elm.firstChild.style.fontSize, '14px');
     patch(vnode1, vnode2);


### PR DESCRIPTION
The first test `explicitly removes styles` passes as expected.

The other two tests fail. Ideally setting a key should ensure that all element and child state is in sync.

Classes have the same issue.