### PR TITLE
Make sure we remove a single text node when patching it's parent element.

### DIFF
--- a/snabbdom.js
+++ b/snabbdom.js
@@ -195,6 +195,7 @@ function init(modules) {
       if (isDef(oldCh) && isDef(ch)) {
         if (oldCh !== ch) updateChildren(elm, oldCh, ch, insertedVnodeQueue);
       } else if (isDef(ch)) {
+        if (isDef(oldVnode.text)) elm.textContent = '';
         addVnodes(elm, null, ch, 0, ch.length - 1, insertedVnodeQueue);
       } else if (isDef(oldCh)) {
         removeVnodes(elm, oldCh, 0, oldCh.length - 1);

--- a/snabbdom.js
+++ b/snabbdom.js
@@ -198,6 +198,8 @@ function init(modules) {
         addVnodes(elm, null, ch, 0, ch.length - 1, insertedVnodeQueue);
       } else if (isDef(oldCh)) {
         removeVnodes(elm, oldCh, 0, oldCh.length - 1);
+      } else if (isDef(oldVnode.text)) {
+        elm.textContent = '';
       }
     } else if (oldVnode.text !== vnode.text) {
       elm.textContent = vnode.text;

--- a/test/core.js
+++ b/test/core.js
@@ -448,6 +448,24 @@ describe('snabbdom', function() {
         patch(vnode1, vnode2);
         assert.deepEqual(map(inner, elm.children), ['One', 'Three']);
       });
+      it('removes a single text node', function() {
+        var vnode1 = h('div', 'One');
+        var vnode2 = h('div');
+        patch(vnode0, vnode1);
+        assert.equal(elm.textContent, 'One');
+        patch(vnode1, vnode2);
+        assert.equal(elm.textContent, '');
+      });
+      it('removes a text node among other elements', function() {
+        var vnode1 = h('div', [ 'One', h('span', 'Two') ]);
+        var vnode2 = h('div', [ h('div', 'Three')]);
+        patch(vnode0, vnode1);
+        assert.deepEqual(map(prop('textContent'), elm.childNodes), ['One', 'Two']);
+        patch(vnode1, vnode2);
+        assert.equal(elm.childNodes.length, 1);
+        assert.equal(elm.childNodes[0].tagName, 'DIV');
+        assert.equal(elm.childNodes[0].textContent, 'Three');
+      });
       it('reorders elements', function() {
         var vnode1 = h('div', [h('span', 'One'), h('div', 'Two'), h('b', 'Three')]);
         var vnode2 = h('div', [h('b', 'Three'), h('span', 'One'), h('div', 'Two')]);

--- a/test/core.js
+++ b/test/core.js
@@ -456,6 +456,15 @@ describe('snabbdom', function() {
         patch(vnode1, vnode2);
         assert.equal(elm.textContent, '');
       });
+      it('removes a single text node when children are updated', function() {
+        var vnode1 = h('div', 'One');
+        var vnode2 = h('div', [ h('div', 'Two'), h('span', 'Three') ]);
+        patch(vnode0, vnode1);
+        assert.equal(elm.textContent, 'One');
+        patch(vnode1, vnode2);
+        console.log(elm.childNodes);
+        assert.deepEqual(map(prop('textContent'), elm.childNodes), ['Two', 'Three']);
+      });
       it('removes a text node among other elements', function() {
         var vnode1 = h('div', [ 'One', h('span', 'Two') ]);
         var vnode2 = h('div', [ h('div', 'Three')]);


### PR DESCRIPTION
When a vnode has a `text` property  and is patched with a vnode with no `text`, the text node is never removed. Similarly, when a vnode has a `text` property and is patched with `children`, the text node created via the old `text` property isn't removed, so you end up the children being appended after the extra text node.
```html
<div>One</div>
``` 
becomes 
```html
<div>One<div>Two</div><span>Three</span></div>
```
instead of 
```html
<div><div>One</div><span>Two</span></div>
```
which, I believe, is unexpected behavior. This adds some test cases to catch this and the fix.