### PR TITLE
Fix cursor jumping to the end of "controlled" inputs

### DIFF
--- a/modules/props.js
+++ b/modules/props.js
@@ -9,7 +9,7 @@ function updateProps(oldVnode, vnode) {
   for (key in props) {
     cur = props[key];
     old = oldProps[key];
-    if (old !== cur) {
+    if (old !== cur && (key !== 'value' || elm[key] !== cur)) {
       elm[key] = cur;
     }
   }


### PR DESCRIPTION
DOM `INPUT.value` should never be updated when it matches the new vnode.

This fixes issues where typing into an INPUT with a sync event handler cause a render (such as for validation feedback) where setting `INPUT.value` also pushes the cursor to the end of the input.