### PR TITLE
Add iframe support.

### DIFF
--- a/snabbdom.js
+++ b/snabbdom.js
@@ -33,6 +33,26 @@ function createRmCb(childElm, listeners) {
   };
 }
 
+// Perform DOM operations differently for iframes.
+function dom(op, elm, first, second) {
+  if (elm.tagName !== 'IFRAME') {
+    if (op === 'textContent') {
+      elm.textContent = first;
+    } else {
+      elm[op](first, second);
+    }
+  } else {
+    // Make sure the iframe is loaded (i.e. we have contentDocument) before
+    // performing operations on the body.
+    var f = function() { dom(op, elm.contentDocument.body, first, second); }
+    if (elm.contentDocument && elm.contentDocument.readyState === 'complete') {
+      f();
+    } else {
+      elm.addEventListener('load', f);
+    }
+  }
+}
+
 var hooks = ['create', 'update', 'remove', 'destroy', 'pre', 'post'];
 
 function init(modules) {

--- a/snabbdom.js
+++ b/snabbdom.js
@@ -29,7 +29,7 @@ function createKeyToOldIdx(children, beginIdx, endIdx) {
 
 function createRmCb(childElm, listeners) {
   return function() {
-    if (--listeners === 0) childElm.parentElement.removeChild(childElm);
+    if (--listeners === 0) dom('removeChild', childElm.parentElement, childElm);
   };
 }
 
@@ -84,10 +84,10 @@ function init(modules) {
       if (dotIdx > 0) elm.className = sel.slice(dot+1).replace(/\./g, ' ');
       if (is.array(children)) {
         for (i = 0; i < children.length; ++i) {
-          elm.appendChild(createElm(children[i], insertedVnodeQueue));
+          dom('appendChild', elm, createElm(children[i], insertedVnodeQueue));
         }
       } else if (is.primitive(vnode.text)) {
-        elm.appendChild(document.createTextNode(vnode.text));
+        dom('appendChild', elm, document.createTextNode(vnode.text));
       }
       for (i = 0; i < cbs.create.length; ++i) cbs.create[i](emptyNode, vnode);
       i = vnode.data.hook; // Reuse variable
@@ -103,7 +103,7 @@ function init(modules) {
 
   function addVnodes(parentElm, before, vnodes, startIdx, endIdx, insertedVnodeQueue) {
     for (; startIdx <= endIdx; ++startIdx) {
-      parentElm.insertBefore(createElm(vnodes[startIdx], insertedVnodeQueue), before);
+      dom('insertBefore', parentElm, createElm(vnodes[startIdx], insertedVnodeQueue), before);
     }
   }
 
@@ -135,7 +135,7 @@ function init(modules) {
             rm();
           }
         } else { // Text node
-          parentElm.removeChild(ch.elm);
+          dom('removeChild', parentElm, ch.elm);
         }
       }
     }
@@ -166,25 +166,25 @@ function init(modules) {
         newEndVnode = newCh[--newEndIdx];
       } else if (sameVnode(oldStartVnode, newEndVnode)) { // Vnode moved right
         patchVnode(oldStartVnode, newEndVnode, insertedVnodeQueue);
-        parentElm.insertBefore(oldStartVnode.elm, oldEndVnode.elm.nextSibling);
+        dom('insertBefore', parentElm, oldStartVnode.elm, oldEndVnode.elm.nextSibling);
         oldStartVnode = oldCh[++oldStartIdx];
         newEndVnode = newCh[--newEndIdx];
       } else if (sameVnode(oldEndVnode, newStartVnode)) { // Vnode moved left
         patchVnode(oldEndVnode, newStartVnode, insertedVnodeQueue);
-        parentElm.insertBefore(oldEndVnode.elm, oldStartVnode.elm);
+        dom('insertBefore', parentElm, oldEndVnode.elm, oldStartVnode.elm);
         oldEndVnode = oldCh[--oldEndIdx];
         newStartVnode = newCh[++newStartIdx];
       } else {
         if (isUndef(oldKeyToIdx)) oldKeyToIdx = createKeyToOldIdx(oldCh, oldStartIdx, oldEndIdx);
         idxInOld = oldKeyToIdx[newStartVnode.key];
         if (isUndef(idxInOld)) { // New element
-          parentElm.insertBefore(createElm(newStartVnode, insertedVnodeQueue), oldStartVnode.elm);
+          dom('insertBefore', parentElm, createElm(newStartVnode, insertedVnodeQueue), oldStartVnode.elm);
           newStartVnode = newCh[++newStartIdx];
         } else {
           elmToMove = oldCh[idxInOld];
           patchVnode(elmToMove, newStartVnode, insertedVnodeQueue);
           oldCh[idxInOld] = undefined;
-          parentElm.insertBefore(elmToMove.elm, oldStartVnode.elm);
+          dom('insertBefore', parentElm, elmToMove.elm, oldStartVnode.elm);
           newStartVnode = newCh[++newStartIdx];
         }
       }
@@ -215,15 +215,15 @@ function init(modules) {
       if (isDef(oldCh) && isDef(ch)) {
         if (oldCh !== ch) updateChildren(elm, oldCh, ch, insertedVnodeQueue);
       } else if (isDef(ch)) {
-        if (isDef(oldVnode.text)) elm.textContent = '';
+        if (isDef(oldVnode.text)) dom('textContent', elm, '');
         addVnodes(elm, null, ch, 0, ch.length - 1, insertedVnodeQueue);
       } else if (isDef(oldCh)) {
         removeVnodes(elm, oldCh, 0, oldCh.length - 1);
       } else if (isDef(oldVnode.text)) {
-        elm.textContent = '';
+        dom(elm, 'textContent', '');
       }
     } else if (oldVnode.text !== vnode.text) {
-      elm.textContent = vnode.text;
+      dom('textContent', elm, vnode.text);
     }
     if (isDef(hook) && isDef(i = hook.postpatch)) {
       i(oldVnode, vnode);

--- a/snabbdom.js
+++ b/snabbdom.js
@@ -220,7 +220,7 @@ function init(modules) {
       } else if (isDef(oldCh)) {
         removeVnodes(elm, oldCh, 0, oldCh.length - 1);
       } else if (isDef(oldVnode.text)) {
-        dom(elm, 'textContent', '');
+        dom('textContent', elm, '');
       }
     } else if (oldVnode.text !== vnode.text) {
       dom('textContent', elm, vnode.text);

--- a/test/core.js
+++ b/test/core.js
@@ -23,6 +23,18 @@ function map(fn, list) {
   return ret;
 }
 
+function whenIframeReady(frame, func) {
+  var doc;
+  if ((doc = frame.contentDocument) && doc.readyState === 'complete') {
+    func(doc.body);
+  }
+  else {
+    frame.addEventListener('load', function() {
+      func(frame.contentDocument.body);
+    });
+  }
+}
+
 var inner = prop('innerHTML');
 
 describe('snabbdom', function() {
@@ -115,7 +127,7 @@ describe('snabbdom', function() {
         frame.onload = function() {
           patch(frame.contentDocument.body.querySelector('div'), h('div', 'Thing 2'));
           assert.equal(frame.contentDocument.body.querySelector('div').textContent, 'Thing 2');
-          frame.remove();
+          frame.parentElement.removeChild(frame);
           done();
         };
         document.body.appendChild(frame);
@@ -124,7 +136,7 @@ describe('snabbdom', function() {
       }
     });
   });
-  describe('pathing an element', function() {
+  describe('patching an element', function() {
     it('changes the elements classes', function() {
       var vnode1 = h('i', {class: {i: true, am: true, horse: true}});
       var vnode2 = h('i', {class: {i: true, am: true, horse: false}});
@@ -584,8 +596,8 @@ describe('snabbdom', function() {
         var result2 = [];
         function cb(result, oldVnode, vnode) {
           if (result.length > 0) {
-            console.log(result[result.length-1]);
-            console.log(oldVnode);
+            // console.log(result[result.length-1]);
+            // console.log(oldVnode);
             assert.strictEqual(result[result.length-1], oldVnode);
           }
           result.push(vnode);
@@ -767,6 +779,498 @@ describe('snabbdom', function() {
       patch(vnode0, vnode1);
       patch(vnode1, vnode2);
       assert.equal(result.length, 0);
+    });
+  });
+  describe('patching an iframe', function() {
+    var vnode1 = null;
+
+    beforeEach(function(){
+      vnode1 = null;
+      vnode0 = document.createElement('iframe');
+      document.body.appendChild(vnode0);
+    });
+    afterEach(function(){
+      if (vnode1 && vnode1.elm) {
+        vnode1.elm.parentElement.removeChild(vnode1.elm);
+      }
+      if (vnode0.parentElement) {
+        vnode0.parentElement.removeChild(vnode0);
+      }
+    });
+    describe('updating children with keys', function() {
+      function spanNum(n) {
+        if (typeof n === 'string') {
+          return h('span', {}, n);
+        } else {
+          return h('span', {key: n}, n.toString());
+        }
+      }
+      describe('addition of elements', function() {
+        it('appends elements', function(done) {
+          vnode1 = h('iframe', [1].map(spanNum));
+          var vnode2 = h('iframe', [1, 2, 3].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 1);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2){
+              assert.equal(b2.children.length, 3);
+              assert.equal(b2.children[1].innerHTML, '2');
+              assert.equal(b2.children[2].innerHTML, '3');
+              done();
+            });
+          });
+        });
+        it('prepends elements', function(done) {
+          vnode1 = h('iframe', [4, 5].map(spanNum));
+          var vnode2 = h('iframe', [1, 2, 3, 4, 5].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 2);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.deepEqual(map(inner, b2.children), ['1', '2', '3', '4', '5']);
+              done();
+            });
+          });
+        });
+        it('add elements in the middle', function(done) {
+          vnode1 = h('iframe', [1, 2, 4, 5].map(spanNum));
+          var vnode2 = h('iframe', [1, 2, 3, 4, 5].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 4);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.deepEqual(map(inner, b2.children), ['1', '2', '3', '4', '5']);
+              done();
+            });
+          });
+        });
+        it('add elements at begin and end', function(done) {
+          vnode1 = h('iframe', [2, 3, 4].map(spanNum));
+          var vnode2 = h('iframe', [1, 2, 3, 4, 5].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 3);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.deepEqual(map(inner, b2.children), ['1', '2', '3', '4', '5']);
+              done();
+            });
+          });
+        });
+        it('adds children to parent with no children', function(done) {
+          vnode1 = h('iframe', {key: 'iframe'});
+          var vnode2 = h('iframe', {key: 'iframe'}, [1, 2, 3].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 0);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.deepEqual(map(inner, b2.children), ['1', '2', '3']);
+              done();
+            });
+          });
+        });
+        it('removes all children from parent', function(done) {
+          vnode1 = h('iframe', {key: 'iframe'}, [1, 2, 3].map(spanNum));
+          var vnode2 = h('iframe', {key: 'iframe'});
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.deepEqual(map(inner, b.children), ['1', '2', '3']);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.equal(b2.children.length, 0);
+              done();
+            });
+          });
+        });
+      });
+      describe('removal of elements', function() {
+        it('removes elements from the beginning', function(done) {
+          vnode1 = h('iframe', [1, 2, 3, 4, 5].map(spanNum));
+          var vnode2 = h('iframe', [3, 4, 5].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 5);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.deepEqual(map(inner, b2.children), ['3', '4', '5']);
+              done();
+            });
+          });
+        });
+        it('removes elements from the end', function(done) {
+          vnode1 = h('iframe', [1, 2, 3, 4, 5].map(spanNum));
+          var vnode2 = h('iframe', [1, 2, 3].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 5);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.equal(b2.children.length, 3);
+              assert.equal(b2.children[0].innerHTML, '1');
+              assert.equal(b2.children[1].innerHTML, '2');
+              assert.equal(b2.children[2].innerHTML, '3');
+              done();
+            });
+          });
+        });
+        it('removes elements from the middle', function(done) {
+          vnode1 = h('iframe', [1, 2, 3, 4, 5].map(spanNum));
+          var vnode2 = h('iframe', [1, 2, 4, 5].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 5);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.equal(b2.children.length, 4);
+              assert.deepEqual(b2.children[0].innerHTML, '1');
+              assert.equal(b2.children[0].innerHTML, '1');
+              assert.equal(b2.children[1].innerHTML, '2');
+              assert.equal(b2.children[2].innerHTML, '4');
+              assert.equal(b2.children[3].innerHTML, '5');
+              done();
+            });
+          });
+        });
+      });
+      describe('element reordering', function() {
+        it('moves element forward', function(done) {
+          vnode1 = h('iframe', [1, 2, 3, 4].map(spanNum));
+          var vnode2 = h('iframe', [2, 3, 1, 4].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 4);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.equal(b2.children.length, 4);
+              assert.equal(b2.children[0].innerHTML, '2');
+              assert.equal(b2.children[1].innerHTML, '3');
+              assert.equal(b2.children[2].innerHTML, '1');
+              assert.equal(b2.children[3].innerHTML, '4');
+              done();
+            });
+          });
+        });
+        it('moves element to end', function(done) {
+          vnode1 = h('iframe', [1, 2, 3].map(spanNum));
+          var vnode2 = h('iframe', [2, 3, 1].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 3);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.equal(b2.children.length, 3);
+              assert.equal(b2.children[0].innerHTML, '2');
+              assert.equal(b2.children[1].innerHTML, '3');
+              assert.equal(b2.children[2].innerHTML, '1');
+              done();
+            });
+          });
+        });
+        it('moves element backwards', function(done) {
+          vnode1 = h('iframe', [1, 2, 3, 4].map(spanNum));
+          var vnode2 = h('iframe', [1, 4, 2, 3].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 4);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.equal(b2.children.length, 4);
+              assert.equal(b2.children[0].innerHTML, '1');
+              assert.equal(b2.children[1].innerHTML, '4');
+              assert.equal(b2.children[2].innerHTML, '2');
+              assert.equal(b2.children[3].innerHTML, '3');
+              done();
+            });
+          });
+        });
+        it('swaps first and last', function(done) {
+          vnode1 = h('iframe', [1, 2, 3, 4].map(spanNum));
+          var vnode2 = h('iframe', [4, 2, 3, 1].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 4);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.equal(b2.children.length, 4);
+              assert.equal(b2.children[0].innerHTML, '4');
+              assert.equal(b2.children[1].innerHTML, '2');
+              assert.equal(b2.children[2].innerHTML, '3');
+              assert.equal(b2.children[3].innerHTML, '1');
+              done();
+            });
+          });
+        });
+      });
+      describe('combinations of additions, removals and reorderings', function() {
+        it('move to left and replace', function(done) {
+          vnode1 = h('iframe', [1, 2, 3, 4, 5].map(spanNum));
+          var vnode2 = h('iframe', [4, 1, 2, 3, 6].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 5);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.equal(b2.children.length, 5);
+              assert.equal(b2.children[0].innerHTML, '4');
+              assert.equal(b2.children[1].innerHTML, '1');
+              assert.equal(b2.children[2].innerHTML, '2');
+              assert.equal(b2.children[3].innerHTML, '3');
+              assert.equal(b2.children[4].innerHTML, '6');
+              done();
+            });
+          });
+        });
+        it('moves to left and leaves hole', function(done) {
+          vnode1 = h('iframe', [1, 4, 5].map(spanNum));
+          var vnode2 = h('iframe', [4, 6].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 3);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.deepEqual(map(inner, b2.children), ['4', '6']);
+              done();
+            });
+          });
+        });
+        it('handles moved and set to undefined element ending at the end', function(done) {
+          vnode1 = h('iframe', [2, 4, 5].map(spanNum));
+          var vnode2 = h('iframe', [4, 5, 3].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.children.length, 3);
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.equal(b2.children.length, 3);
+              assert.equal(b2.children[0].innerHTML, '4');
+              assert.equal(b2.children[1].innerHTML, '5');
+              assert.equal(b2.children[2].innerHTML, '3');
+              done();
+            });
+          });
+        });
+        it('moves a key in non-keyed nodes with a size up', function(done) {
+          vnode1 = h('iframe', [1, 'a', 'b', 'c'].map(spanNum));
+          var vnode2 = h('iframe', ['d', 'a', 'b', 'c', 1, 'e'].map(spanNum));
+          patch(vnode0, vnode1);
+          whenIframeReady(vnode1.elm, function(b) {
+            assert.equal(b.childNodes.length, 4);
+            assert.equal(b.textContent, '1abc');
+            patch(vnode1, vnode2);
+            whenIframeReady(vnode2.elm, function(b2) {
+              assert.equal(b2.childNodes.length, 6);
+              assert.equal(b2.textContent, 'dabc1e');
+              done();
+            });
+          });
+        });
+      });
+      it('reverses elements', function(done) {
+        vnode1 = h('iframe', [1, 2, 3, 4, 5, 6, 7, 8].map(spanNum));
+        var vnode2 = h('iframe', [8, 7, 6, 5, 4, 3, 2, 1].map(spanNum));
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.equal(b.children.length, 8);
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2){
+            assert.deepEqual(map(inner, b2.children), ['8', '7', '6', '5', '4', '3', '2', '1']);
+            done();
+          });
+        });
+      });
+      it('something', function(done) {
+        vnode1 = h('iframe', [0, 1, 2, 3, 4, 5].map(spanNum));
+        var vnode2 = h('iframe', [4, 3, 2, 1, 5, 0].map(spanNum));
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.equal(b.children.length, 6);
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.deepEqual(map(inner, b2.children), ['4', '3', '2', '1', '5', '0']);
+            done();
+          });
+        });
+      });
+      it('handles random shuffles', function(done) {
+        var n, i, arr = [], opacities = [], elms = 14, samples = 5;
+        function spanNumWithOpacity(n, o) {
+          return h('span', {key: n, style: {opacity: o}}, n.toString());
+        }
+        var vnodes0 = [],
+            vnodes1 = [],
+            vnodes2 = [];
+        for (n = 0; n < elms; ++n) { arr[n] = n; }
+        for (n = 0; n < samples; ++n) {
+          vnodes1[n] = h('iframe',arr.map(function(n) {
+            return spanNumWithOpacity(n, '1');
+          }));
+          var shufArr = shuffle(arr.slice(0));
+          vnodes0[n] = document.createElement('iframe');
+          document.body.appendChild(vnodes0[n]);
+          patch(vnodes0[n], vnodes1[n]);
+          whenIframeReady(vnodes1[n].elm, (function(idx) { return function(b) {
+            for (i = 0; i < elms; ++i) {
+              assert.equal(b.children[i].innerHTML, i.toString());
+              opacities[i] = Math.random().toFixed(5).toString();
+            }
+            vnodes2[idx] = h('iframe', { props: { testFrameId: idx } }, arr.map(function(n) {
+              return spanNumWithOpacity(shufArr[n], opacities[n]);
+            }));
+            patch(vnodes1[idx], vnodes2[idx]);
+            whenIframeReady(vnodes2[idx].elm, function(b2) {
+              for (i = 0; i < elms; ++i) {
+                assert.equal(b2.children[i].innerHTML, shufArr[i].toString());
+                assert.equal(opacities[i].indexOf(b2.children[i].style.opacity), 0);
+              }
+              // Clean up the iframe.
+              vnodes2[idx].elm.parentElement.removeChild(vnodes2[idx].elm);
+              if (idx+1 === samples) {
+                done();
+              }
+            });
+          }; })(n));
+        }
+      });
+    });
+    describe('updating children without keys', function() {
+      it('appends elements', function(done) {
+        vnode1 = h('iframe', [h('span', 'Hello')]);
+        var vnode2 = h('iframe', [h('span', 'Hello'), h('span', 'World')]);
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.deepEqual(map(inner, b.children), ['Hello']);
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.deepEqual(map(inner, b2.children), ['Hello', 'World']);
+            done();
+          });
+        });
+      });
+      it('handles unmoved text nodes', function(done) {
+        vnode1 = h('iframe', ['Text', h('span', 'Span')]);
+        var vnode2 = h('iframe', ['Text', h('span', 'Span')]);
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.equal(b.childNodes[0].textContent, 'Text');
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.equal(b2.childNodes[0].textContent, 'Text');
+            done();
+          });
+        });
+      });
+      it('handles changing text children', function(done) {
+        vnode1 = h('iframe', ['Text', h('span', 'Span')]);
+        var vnode2 = h('iframe', ['Text2', h('span', 'Span')]);
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.equal(b.childNodes[0].textContent, 'Text');
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.equal(b2.childNodes[0].textContent, 'Text2');
+            done();
+          });
+        });
+      });
+      it('prepends element', function(done) {
+        vnode1 = h('iframe', [h('span', 'World')]);
+        var vnode2 = h('iframe', [h('span', 'Hello'), h('span', 'World')]);
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.deepEqual(map(inner, b.children), ['World']);
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.deepEqual(map(inner, b2.children), ['Hello', 'World']);
+            done();
+          });
+        });
+      });
+      it('prepends element of different tag type', function(done) {
+        vnode1 = h('iframe', [h('span', 'World')]);
+        var vnode2 = h('iframe', [h('div', 'Hello'), h('span', 'World')]);
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.deepEqual(map(inner, b.children), ['World']);
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.deepEqual(map(prop('tagName'), b2.children), ['DIV', 'SPAN']);
+            assert.deepEqual(map(inner, b2.children), ['Hello', 'World']);
+            done();
+          });
+        });
+      });
+      it('removes elements', function(done) {
+        vnode1 = h('iframe', [h('span', 'One'), h('span', 'Two'), h('span', 'Three')]);
+        var vnode2 = h('iframe', [h('span', 'One'), h('span', 'Three')]);
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.deepEqual(map(inner, b.children), ['One', 'Two', 'Three']);
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.deepEqual(map(inner, b2.children), ['One', 'Three']);
+            done();
+          });
+        });
+      });
+      it('removes a single text node', function(done) {
+        vnode1 = h('iframe', 'One');
+        var vnode2 = h('iframe');
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.equal(b.textContent, 'One');
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.equal(b2.textContent, '');
+            done();
+          });
+        });
+      });
+      it('removes a single text node when children are updated', function(done) {
+        vnode1 = h('iframe', 'One');
+        var vnode2 = h('iframe', [ h('div', 'Two'), h('span', 'Three') ]);
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.equal(b.textContent, 'One');
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.deepEqual(map(prop('textContent'), b2.childNodes), ['Two', 'Three']);
+            done();
+          });
+        });
+      });
+      it('removes a text node among other elements', function(done) {
+        vnode1 = h('iframe', [ 'One', h('span', 'Two') ]);
+        var vnode2 = h('iframe', [ h('div', 'Three')]);
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.deepEqual(map(prop('textContent'), b.childNodes), ['One', 'Two']);
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.equal(b2.childNodes.length, 1);
+            assert.equal(b2.childNodes[0].tagName, 'DIV');
+            assert.equal(b2.childNodes[0].textContent, 'Three');
+            done();
+          });
+        });
+      });
+      it('reorders elements', function(done) {
+        vnode1 = h('iframe', [h('span', 'One'), h('div', 'Two'), h('b', 'Three')]);
+        var vnode2 = h('iframe', [h('b', 'Three'), h('span', 'One'), h('div', 'Two')]);
+        patch(vnode0, vnode1);
+        whenIframeReady(vnode1.elm, function(b) {
+          assert.deepEqual(map(inner, b.children), ['One', 'Two', 'Three']);
+          patch(vnode1, vnode2);
+          whenIframeReady(vnode2.elm, function(b2) {
+            assert.deepEqual(map(prop('tagName'), b2.children), ['B', 'SPAN', 'DIV']);
+            assert.deepEqual(map(inner, b2.children), ['Three', 'One', 'Two']);
+            done();
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Not sure if you'll want to include this in snabbdom or not but figured I'd throw it out there. These changes allow proper patching of `<iframe>` elements. This would allow one to do something like:
```javascript
var vnode0 = document.createElement('iframe');
document.body.appendChild(vnode0);
var vnode1 = h('iframe', [
    h('ul', [
        h('li', 'Thing 1'),
        h('li', 'Thing 2')
    ]),
    h('span', 'Another thing.')
]);
patch(vnode0, vnode1);
patch(vnode1, h('iframe', [
    h('ul', [
        h('li', 'Thing 0'),
        h('li', 'Thing 1'),
        h('li', 'Thing 2')
    ])
]));
```
And the childNodes will be added/removed from the `contentDocument.body` of the iframe when the iframe is fully ready/loaded. 

In our application, we're using iframes to sandbox certain content, which is why I'm hoping to be able to perform patches on iframes. The main issue with trying to patch iframes is that appending a child to the iframe doesn't do what one would expect - we really should append children to the body of the iframe, so that they appear on the page. The basic gist of this PR is that I've added a function for performing abstracted DOM operations. It performs differently when applied to an iframe vs. a "normal" element. For an iframe it waits until the iframe is ready/loaded and then performs the DOM operation specified on the `contentDocument.body` of the iframe. I wrote the function as small as I could manage so as to not bloat the snabbdom codebase (which also means that it's not as clear/obvious as it could be, although I think it's still easy enough to follow). I also duplicated most of the core tests to verify that they work when patching `<iframe>` elements.

I'd tried adding support for iframes as a snabbdom plugin but the only workable solution seems to be to perform different DOM operations for the special case of iframes.

Let me know what you think! Thanks!