### PR TITLE
Catch errors thrown trying to set input type

### DIFF
--- a/modules/props.js
+++ b/modules/props.js
@@ -12,7 +12,7 @@ function updateProps(oldVnode, vnode) {
     if (old !== cur && (key !== 'value' || elm[key] !== cur)) {
       if (key !== 'type') elm[key] = cur;
       else {
-        try { elm[key] = cur; } catch (e) { elm.type = 'text' };
+        try { elm.type = cur; } catch (e) { elm.type = 'text'; }
       }
     }
   }

--- a/modules/props.js
+++ b/modules/props.js
@@ -10,7 +10,10 @@ function updateProps(oldVnode, vnode) {
     cur = props[key];
     old = oldProps[key];
     if (old !== cur && (key !== 'value' || elm[key] !== cur)) {
-      elm[key] = cur;
+      if (key !== 'type') elm[key] = cur;
+      else {
+        try { elm[key] = cur; } catch (e) { elm.type = 'text' };
+      }
     }
   }
 }

--- a/modules/props.js
+++ b/modules/props.js
@@ -12,7 +12,7 @@ function updateProps(oldVnode, vnode) {
     if (old !== cur && (key !== 'value' || elm[key] !== cur)) {
       if (key !== 'type') elm[key] = cur;
       else {
-        try { elm.type = cur; } catch (e) { elm.type = 'text'; }
+        try { elm.type = cur; } catch (e) { delete elm.type; }
       }
     }
   }


### PR DESCRIPTION
IE eats it if an unsupported input type is attempted to be set. This patch drops into a try/catch if the prop is `type` and ~~defaults to `text` if it fails~~ deletes the `type` property if it fails. In that case the browser will fallback to the default type for the element.