### PR TITLE
Fix safety check for requestAnimationFrame

### DIFF
--- a/modules/hero.js
+++ b/modules/hero.js
@@ -1,4 +1,4 @@
-var raf = (window && window.requestAnimationFrame) || setTimeout;
+var raf = (typeof window !== `undefined` && window.requestAnimationFrame) || setTimeout;
 var nextFrame = function(fn) { raf(function() { raf(fn); }); };
 
 function setNextFrame(obj, prop, val) {

--- a/modules/style.js
+++ b/modules/style.js
@@ -1,4 +1,4 @@
-var raf = (window && window.requestAnimationFrame) || setTimeout;
+var raf = (typeof window !== `undefined` && window.requestAnimationFrame) || setTimeout;
 var nextFrame = function(fn) { raf(function() { raf(fn); }); };
 
 function setNextFrame(obj, prop, val) {


### PR DESCRIPTION
Doing `window &&` does not achieve the expected behavior, it instead crashes with an error `ReferenceError: window is not defined`. This fix is simple and necessary for server-side rendering.