### PR TITLE
h: Test args for defined values instead of args.length

### DIFF
--- a/h.js
+++ b/h.js
@@ -12,11 +12,11 @@ function addNS(data, children) {
 
 module.exports = function h(sel, b, c) {
   var data = {}, children, text, i;
-  if (arguments.length === 3) {
+  if (c !== undefined) {
     data = b;
     if (is.array(c)) { children = c; }
     else if (is.primitive(c)) { text = c; }
-  } else if (arguments.length === 2) {
+  } else if (b !== undefined) {
     if (is.array(b)) { children = b; }
     else if (is.primitive(b)) { text = b; }
     else { data = b; }


### PR DESCRIPTION
In my app, I am wrapping calls to `h` with another helper. This helper passes through args to `h` after applying some logic, as in:

```js
function helper(first, second, ...rest) {
  // ... logic ...
  h(first, second, ...rest);
}
```

Checking `arguments.length` causes this helper to fail, since it is just passing through values, so there could be only 2 "truthy" arguments, but `h` would receive `h(first, second, undefined)`, breaking the argument processing in `h`.

Switching to truthy checks appears to solve this and preserve previous behavior. What do you think of this?

Thanks for working on this library! :smile: