### PR TITLE
Return early in module update functions

### DIFF
--- a/modules/attributes.js
+++ b/modules/attributes.js
@@ -1,19 +1,23 @@
-var booleanAttrs = ["allowfullscreen", "async", "autofocus", "autoplay", "checked", "compact", "controls", "declare", 
-                "default", "defaultchecked", "defaultmuted", "defaultselected", "defer", "disabled", "draggable", 
-                "enabled", "formnovalidate", "hidden", "indeterminate", "inert", "ismap", "itemscope", "loop", "multiple", 
-                "muted", "nohref", "noresize", "noshade", "novalidate", "nowrap", "open", "pauseonexit", "readonly", 
-                "required", "reversed", "scoped", "seamless", "selected", "sortable", "spellcheck", "translate", 
+var booleanAttrs = ["allowfullscreen", "async", "autofocus", "autoplay", "checked", "compact", "controls", "declare",
+                "default", "defaultchecked", "defaultmuted", "defaultselected", "defer", "disabled", "draggable",
+                "enabled", "formnovalidate", "hidden", "indeterminate", "inert", "ismap", "itemscope", "loop", "multiple",
+                "muted", "nohref", "noresize", "noshade", "novalidate", "nowrap", "open", "pauseonexit", "readonly",
+                "required", "reversed", "scoped", "seamless", "selected", "sortable", "spellcheck", "translate",
                 "truespeed", "typemustmatch", "visible"];
-    
+
 var booleanAttrsDict = {};
 for(var i=0, len = booleanAttrs.length; i < len; i++) {
   booleanAttrsDict[booleanAttrs[i]] = true;
 }
-    
+
 function updateAttrs(oldVnode, vnode) {
   var key, cur, old, elm = vnode.elm,
-      oldAttrs = oldVnode.data.attrs || {}, attrs = vnode.data.attrs || {};
-  
+      oldAttrs = oldVnode.data.attrs, attrs = vnode.data.attrs;
+
+  if (!oldAttrs && !attrs) return;
+  oldAttrs = oldAttrs || {};
+  attrs = attrs || {};
+
   // update modified attributes, add new attributes
   for (key in attrs) {
     cur = attrs[key];

--- a/modules/class.js
+++ b/modules/class.js
@@ -1,7 +1,12 @@
 function updateClass(oldVnode, vnode) {
   var cur, name, elm = vnode.elm,
-      oldClass = oldVnode.data.class || {},
-      klass = vnode.data.class || {};
+      oldClass = oldVnode.data.class,
+      klass = vnode.data.class;
+
+  if (!oldClass && !klass) return;
+  oldClass = oldClass || {};
+  klass = klass || {};
+
   for (name in oldClass) {
     if (!klass[name]) {
       elm.classList.remove(name);

--- a/modules/dataset.js
+++ b/modules/dataset.js
@@ -1,8 +1,12 @@
 function updateDataset(oldVnode, vnode) {
   var elm = vnode.elm,
-    oldDataset = oldVnode.data.dataset || {},
-    dataset = vnode.data.dataset || {},
+    oldDataset = oldVnode.data.dataset,
+    dataset = vnode.data.dataset,
     key
+
+  if (!oldDataset && !dataset) return;
+  oldDataset = oldDataset || {};
+  dataset = dataset || {};
 
   for (key in oldDataset) {
     if (!dataset[key]) {

--- a/modules/eventlisteners.js
+++ b/modules/eventlisteners.js
@@ -13,8 +13,12 @@ function fnInvoker(o) {
 
 function updateEventListeners(oldVnode, vnode) {
   var name, cur, old, elm = vnode.elm,
-      oldOn = oldVnode.data.on || {}, on = vnode.data.on;
-  if (!on) return;
+      oldOn = oldVnode.data.on, on = vnode.data.on;
+
+  if (!on && !oldOn) return;
+  on = on || {};
+  oldOn = oldOn || {};
+
   for (name in on) {
     cur = on[name];
     old = oldOn[name];

--- a/modules/props.js
+++ b/modules/props.js
@@ -1,6 +1,11 @@
 function updateProps(oldVnode, vnode) {
   var key, cur, old, elm = vnode.elm,
-      oldProps = oldVnode.data.props || {}, props = vnode.data.props || {};
+      oldProps = oldVnode.data.props, props = vnode.data.props;
+
+  if (!oldProps && !props) return;
+  oldProps = oldProps || {};
+  props = props || {};
+
   for (key in oldProps) {
     if (!props[key]) {
       delete elm[key];

--- a/modules/style.js
+++ b/modules/style.js
@@ -7,9 +7,14 @@ function setNextFrame(obj, prop, val) {
 
 function updateStyle(oldVnode, vnode) {
   var cur, name, elm = vnode.elm,
-      oldStyle = oldVnode.data.style || {},
-      style = vnode.data.style || {},
-      oldHasDel = 'delayed' in oldStyle;
+      oldStyle = oldVnode.data.style,
+      style = vnode.data.style;
+
+  if (!oldStyle && !style) return;
+  oldStyle = oldStyle || {};
+  style = style || {};
+  var oldHasDel = 'delayed' in oldStyle;
+
   for (name in oldStyle) {
     if (!style[name]) {
       elm.style[name] = '';


### PR DESCRIPTION
Currently for each module, on every update, for every node, empty objects are allocated, enumerated and iterated over regardless of whether that node has data for the module or not.

Returning early prevents useless object allocation and `for ... in` enumeration, which should result in better memory usage and more efficient patching.

I'm observing around 10% fps increase in the dbmon benchmark.