### PR TITLE
eventlisteners should work if a listener is removed

### DIFF
--- a/modules/eventlisteners.js
+++ b/modules/eventlisteners.js
@@ -2,13 +2,17 @@ var is = require('../is');
 
 function arrInvoker(arr) {
   return function() {
+    if (!arr.length) return;
     // Special case when length is two, for performance
     arr.length === 2 ? arr[0](arr[1]) : arr[0].apply(undefined, arr.slice(1));
   };
 }
 
 function fnInvoker(o) {
-  return function(ev) { o.fn(ev); };
+  return function(ev) { 
+    if (o.fn === null) return;
+    o.fn(ev); 
+  };
 }
 
 function updateEventListeners(oldVnode, vnode) {
@@ -36,6 +40,19 @@ function updateEventListeners(oldVnode, vnode) {
       on[name] = old;
     }
   }
+  if (oldOn) {
+		for (name in oldOn) {
+			if (on[name] === undefined) {
+				var old = oldOn[name];
+				if (is.array(old)) {
+					old.length = 0;
+				}
+				else {
+					old.fn = null;
+				}
+			}
+		}
+	}
 }
 
 module.exports = {create: updateEventListeners, update: updateEventListeners};

--- a/modules/eventlisteners.js
+++ b/modules/eventlisteners.js
@@ -41,18 +41,18 @@ function updateEventListeners(oldVnode, vnode) {
     }
   }
   if (oldOn) {
-		for (name in oldOn) {
-			if (on[name] === undefined) {
-				var old = oldOn[name];
-				if (is.array(old)) {
-					old.length = 0;
-				}
-				else {
-					old.fn = null;
-				}
-			}
-		}
-	}
+    for (name in oldOn) {
+      if (on[name] === undefined) {
+        var old = oldOn[name];
+        if (is.array(old)) {
+          old.length = 0;
+        }
+        else {
+          old.fn = null;
+        }
+      }
+    }
+  }
 }
 
 module.exports = {create: updateEventListeners, update: updateEventListeners};


### PR DESCRIPTION
In the current version, a event-listener is never removed, which leads to problems in certain use cases. This patch fixes this.

(I hope I got everything correct, because I made this changes online).