### PR TITLE
Don't overwrite other class attribute assignments.

### DIFF
--- a/modules/attributes.js
+++ b/modules/attributes.js
@@ -19,11 +19,18 @@ function updateAttrs(oldVnode, vnode) {
     cur = attrs[key];
     old = oldAttrs[key];
     if (old !== cur) {
-      // TODO: add support to namespaced attributes (setAttributeNS)
-      if(!cur && booleanAttrsDict[key])
-        elm.removeAttribute(key);
-      else
-        elm.setAttribute(key, cur);
+      if ('class' === key) {
+        var clslst = cur.split(/ +/);
+        for (i = 0; i < clslst.length; i++) {
+          elm.classList.add(clslst[i]);
+        }
+      } else {
+        // TODO: add support to namespaced attributes (setAttributeNS)
+        if(!cur && booleanAttrsDict[key])
+          elm.removeAttribute(key);
+        else
+          elm.setAttribute(key, cur);
+      }
     }
   }
   //remove removed attributes


### PR DESCRIPTION
When a snabbdom virtual node has both a class as a component of the `sel` property AND a property in an `attrs` object, the `attrs` object class overwrites the `sel` subcomponent class.

https://github.com/paldepind/snabbdom/blob/master/modules/attributes.js#L26
`elm.setAttribute(key, cur);`

Here's an example of `attrs` class overwriting `sel` subcomponent class:
http://esnextb.in/?gist=0512c49748550e57039bce437225081e

To prevent overwriting I suggest adding a check to determine if `key` equals "class", and if so use `classList.add` rather than `setAttribute`. 

Also to accommodate a list of classes in the `attrs` class property, `split` the value on spaces and loop over the resulting array adding each item.