### PR TITLE
126 svg foreignobject

### DIFF
--- a/h.js
+++ b/h.js
@@ -1,11 +1,12 @@
 var VNode = require('./vnode');
 var is = require('./is');
 
-function addNS(data, children) {
+function addNS(data, children, sel) {
   data.ns = 'http://www.w3.org/2000/svg';
-  if (children !== undefined) {
+
+  if (sel !== 'foreignObject' && children !== undefined) {
     for (var i = 0; i < children.length; ++i) {
-      addNS(children[i].data, children[i].children);
+      addNS(children[i].data, children[i].children, children[i].sel);
     }
   }
 }
@@ -27,7 +28,7 @@ module.exports = function h(sel, b, c) {
     }
   }
   if (sel[0] === 's' && sel[1] === 'v' && sel[2] === 'g') {
-    addNS(data, children);
+    addNS(data, children, sel);
   }
   return VNode(sel, data, children, text, undefined);
 };

--- a/test/core.js
+++ b/test/core.js
@@ -73,8 +73,21 @@ describe('snabbdom', function() {
       assert.equal(elm.firstChild.id, 'unique');
     });
     it('has correct namespace', function() {
-      elm = patch(vnode0, h('div', [h('div', {ns: 'http://www.w3.org/2000/svg'})])).elm;
-      assert.equal(elm.firstChild.namespaceURI, 'http://www.w3.org/2000/svg');
+      var SVGNamespace = 'http://www.w3.org/2000/svg';
+      var XHTMLNamespace = 'http://www.w3.org/1999/xhtml';
+
+      elm = patch(vnode0, h('div', [h('div', {ns: SVGNamespace})])).elm;
+      assert.equal(elm.firstChild.namespaceURI, SVGNamespace);
+
+      elm = patch(vnode0, h('svg', [
+        h('foreignObject', [
+          h('div', ['I am HTML embedded in SVG'])
+        ])
+      ])).elm;
+
+      assert.equal(elm.namespaceURI, SVGNamespace);
+      assert.equal(elm.firstChild.namespaceURI, SVGNamespace);
+      assert.equal(elm.firstChild.firstChild.namespaceURI, XHTMLNamespace);
     });
     it('is recieves classes in selector', function() {
       elm = patch(vnode0, h('div', [h('i.am.a.class')])).elm;


### PR DESCRIPTION
Hi there,

This PR adds a new condition to the `addNS` function to halt recursion if it encounters the `foreignObject` SVG element. The result of this is that embedded HTML elements now retain the correct namespace (`http://www.w3.org/1999/xhtml`) and should render correctly inside the SVG parent.

I've appended a few new assertions to the existing namespace test case, but please let me know if there is a smarter way to do any of this! 

P.s I had some troubles running the tests whereby the page continuously reloads in both Firefox and Chrome. I was able to see the new tests passing/failing as i'd expect, but I'm not sure if there's something going wrong with the test runner?

Thanks 😄 