### PR TITLE
Prevent test runner from continuously reloading

### DIFF
--- a/testem.json
+++ b/testem.json
@@ -5,9 +5,9 @@
     "test/*.js"
   ],
   "serve_files": [
-    "test/browserified.js"
+    "browserified.js"
   ],
-  "before_tests": "browserify -d test/index.js -o test/browserified.js",
-  "on_exit": "rm test/browserified.js",
+  "before_tests": "browserify -d test/index.js -o browserified.js",
+  "on_exit": "rm browserified.js",
   "launch_in_dev": [ "firefox", "chromium" ]
 }


### PR DESCRIPTION
Hi there,

This PR should prevent the endless reload loop I was seeing while running the tests (as mentioned in https://github.com/paldepind/snabbdom/pull/133)

It looks like running the tests (first via `npm test`) tells testem to browserify the test files (during `before_tests`) and create the output file in the `test` dir, which triggers the watcher from `src_files` causing the tests to run again and so on...

I've moved the browserify output file to outside of the watched dir so its generation doesn't cause the test runner to restart. This appears to stop the reloading issue and the test runner now works as I expected, reloading the tests when a change to a spec file is made.

Please let me know if this is not what you expect 😄 