### PR TITLE
handle the case when the SVG element is a <text> and the child is a string

### DIFF
--- a/h.js
+++ b/h.js
@@ -2,8 +2,9 @@ var VNode = require('./vnode');
 var is = require('./is');
 
 function addNS(data, children, sel) {
-  data.ns = 'http://www.w3.org/2000/svg';
-
+  if (data !== undefined) {
+    data.ns = 'http://www.w3.org/2000/svg';
+  }
   if (sel !== 'foreignObject' && children !== undefined) {
     for (var i = 0; i < children.length; ++i) {
       addNS(children[i].data, children[i].children, children[i].sel);


### PR DESCRIPTION
Be able to handle the [<text>](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/text) element so that SVG text can be rendered. Currently, an error is raised.